### PR TITLE
Implemented suggestions from Harro

### DIFF
--- a/Base.lproj/Localizable.strings
+++ b/Base.lproj/Localizable.strings
@@ -5,22 +5,19 @@
   Created by Lizzy Randall on 6/15/15.
   Copyright (c) 2015 Lizzy Randall. All rights reserved.
 */
-/*Filter - helpful to have a number of some sort so # __ items"*/
-"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@";
-/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller*/
-"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
-"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
-/*If entitiy gets selected for filter, the text will say # selected ...*/
-"MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
+/*FilterViewController strings, please note most of these have number in placement, required for any language*/
+/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller includes # identifier*/
+"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "%i item";
+"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "%i items";
 /*Filter text entity for labels*/
-"MHFilterViewController_Interaction_CellHeader_label_single" = "selected label";
-"MHFilterViewController_Interaction_CellHeader_label_plural" = "selected labels";
+"MHFilterViewController_Interaction_CellHeader_label_single" = "%i selected label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "%i selected labels";
 /*Filter text entities for surveys*/
-"MHFilterViewController_Interaction_CellHeader_survey_single" = "selected survey";
-"MHFilterViewController_Interaction_CellHeader_survey_plural" = "selected surveys";
-"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "selected question";
-"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "selected questions";
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "%i selected survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "%i selected surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "%i selected question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "%i selected questions";
 "MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
 /*Filter Text entity for interactions*/
-"MHFilterViewController_Interaction_CellHeader_interaction_single" = "selected interaction";
-"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "selected interactions";
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "%i selected interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "%i selected interactions";

--- a/Base.lproj/Localizable.strings
+++ b/Base.lproj/Localizable.strings
@@ -1,0 +1,20 @@
+/* 
+  Localizable.strings
+  CollapsibleExample
+
+  Created by Lizzy Randall on 6/15/15.
+  Copyright (c) 2015 Lizzy Randall. All rights reserved.
+*/
+"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@ %@";
+"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
+"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
+"MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
+"MHFilterViewController_Interaction_CellHeader_label_single" = "label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "labels";
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "questions";
+"MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "interactions";

--- a/Base.lproj/Localizable.strings
+++ b/Base.lproj/Localizable.strings
@@ -5,16 +5,22 @@
   Created by Lizzy Randall on 6/15/15.
   Copyright (c) 2015 Lizzy Randall. All rights reserved.
 */
+/*Filter - helpful to have a number of some sort so # __ items"*/
 "MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@ %@";
+/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller*/
 "MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
 "MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
+/*If entitiy gets selected for filter, the text will say # selected ...*/
 "MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
+/*Filter text entity for labels*/
 "MHFilterViewController_Interaction_CellHeader_label_single" = "label";
 "MHFilterViewController_Interaction_CellHeader_label_plural" = "labels";
+/*Filter text entities for surveys*/
 "MHFilterViewController_Interaction_CellHeader_survey_single" = "survey";
 "MHFilterViewController_Interaction_CellHeader_survey_plural" = "surveys";
 "MHFilterViewController_Interaction_CellHeader_survey_question_single" = "question";
 "MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "questions";
 "MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
+/*Filter Text entity for interactions*/
 "MHFilterViewController_Interaction_CellHeader_interaction_single" = "interaction";
 "MHFilterViewController_Interaction_CellHeader_interaction_plural" = "interactions";

--- a/Base.lproj/Localizable.strings
+++ b/Base.lproj/Localizable.strings
@@ -6,21 +6,21 @@
   Copyright (c) 2015 Lizzy Randall. All rights reserved.
 */
 /*Filter - helpful to have a number of some sort so # __ items"*/
-"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@ %@";
+"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@";
 /*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller*/
 "MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
 "MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
 /*If entitiy gets selected for filter, the text will say # selected ...*/
 "MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
 /*Filter text entity for labels*/
-"MHFilterViewController_Interaction_CellHeader_label_single" = "label";
-"MHFilterViewController_Interaction_CellHeader_label_plural" = "labels";
+"MHFilterViewController_Interaction_CellHeader_label_single" = "selected label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "selected labels";
 /*Filter text entities for surveys*/
-"MHFilterViewController_Interaction_CellHeader_survey_single" = "survey";
-"MHFilterViewController_Interaction_CellHeader_survey_plural" = "surveys";
-"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "question";
-"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "questions";
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "selected survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "selected surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "selected question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "selected questions";
 "MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
 /*Filter Text entity for interactions*/
-"MHFilterViewController_Interaction_CellHeader_interaction_single" = "interaction";
-"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "interactions";
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "selected interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "selected interactions";

--- a/CollapsibleExample.xcodeproj/project.pbxproj
+++ b/CollapsibleExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		83ACD4881B190CF9000F6F05 /* MHCollapseUpArrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 83ACD4861B190CF9000F6F05 /* MHCollapseUpArrow.png */; };
 		83B11E2D1B28B40A00DE28AE /* MHPackagedFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83B11E2C1B28B40A00DE28AE /* MHPackagedFilter.m */; };
 		83B11E301B28BB3A00DE28AE /* MHKeyValuePair.m in Sources */ = {isa = PBXBuildFile; fileRef = 83B11E2F1B28BB3A00DE28AE /* MHKeyValuePair.m */; };
+		83B7FC5E1B2F2A8800BD0441 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 83B7FC601B2F2A8800BD0441 /* Localizable.strings */; };
 		83D4CB0A1B023845001C9A72 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D4CB091B023845001C9A72 /* main.m */; };
 		83D4CB0D1B023845001C9A72 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D4CB0C1B023845001C9A72 /* AppDelegate.m */; };
 		83D4CB101B023845001C9A72 /* CollapsibleExample.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 83D4CB0E1B023845001C9A72 /* CollapsibleExample.xcdatamodeld */; };
@@ -51,6 +52,8 @@
 		83B11E2C1B28B40A00DE28AE /* MHPackagedFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHPackagedFilter.m; sourceTree = "<group>"; };
 		83B11E2E1B28BB3A00DE28AE /* MHKeyValuePair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHKeyValuePair.h; sourceTree = "<group>"; };
 		83B11E2F1B28BB3A00DE28AE /* MHKeyValuePair.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHKeyValuePair.m; sourceTree = "<group>"; };
+		83B7FC5F1B2F2A8800BD0441 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		83B7FC611B2F2DC100BD0441 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		83D4CB041B023845001C9A72 /* CollapsibleExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollapsibleExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		83D4CB081B023845001C9A72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83D4CB091B023845001C9A72 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -171,6 +174,7 @@
 		83D4CB461B024C03001C9A72 /* Object Types */ = {
 			isa = PBXGroup;
 			children = (
+				83B7FC601B2F2A8800BD0441 /* Localizable.strings */,
 				83ACD4851B190CF9000F6F05 /* MHCollapseDownArrow.png */,
 				83ACD4861B190CF9000F6F05 /* MHCollapseUpArrow.png */,
 				830349C11B0BBDCD000B03C0 /* MHCollapsibleSection.h */,
@@ -270,6 +274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83ACD4881B190CF9000F6F05 /* MHCollapseUpArrow.png in Resources */,
+				83B7FC5E1B2F2A8800BD0441 /* Localizable.strings in Resources */,
 				83D4CB161B023845001C9A72 /* Main.storyboard in Resources */,
 				83D4CB1B1B023845001C9A72 /* LaunchScreen.xib in Resources */,
 				83ACD4871B190CF9000F6F05 /* MHCollapseDownArrow.png in Resources */,
@@ -326,6 +331,16 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		83B7FC601B2F2A8800BD0441 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				83B7FC5F1B2F2A8800BD0441 /* Base */,
+				83B7FC611B2F2DC100BD0441 /* en */,
+			);
+			name = Localizable.strings;
+			path = ..;
+			sourceTree = "<group>";
+		};
 		83D4CB141B023845001C9A72 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/CollapsibleExample.xcodeproj/project.pbxproj
+++ b/CollapsibleExample.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		83B11E2F1B28BB3A00DE28AE /* MHKeyValuePair.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHKeyValuePair.m; sourceTree = "<group>"; };
 		83B7FC5F1B2F2A8800BD0441 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		83B7FC611B2F2DC100BD0441 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		83B7FC631B2F556500BD0441 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		83D4CB041B023845001C9A72 /* CollapsibleExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollapsibleExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		83D4CB081B023845001C9A72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83D4CB091B023845001C9A72 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -345,6 +346,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				83D4CB151B023845001C9A72 /* Base */,
+				83B7FC631B2F556500BD0441 /* en */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";

--- a/CollapsibleExample/Base.lproj/Main.storyboard
+++ b/CollapsibleExample/Base.lproj/Main.storyboard
@@ -64,7 +64,7 @@
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="89S-va-4z4">
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="10O-kb-IB0">

--- a/CollapsibleExample/ExampleSubclassFilterViewController.m
+++ b/CollapsibleExample/ExampleSubclassFilterViewController.m
@@ -53,9 +53,15 @@
     
     //do not do plural, just singleton
     //this identifies uniquely what the filters are
-    [labels setTextIdentifierAndIndexWithString:@"label" rootText:@"label" managerIndex:0];
-    [surveys setTextIdentifierAndIndexWithString:@"question" rootText:@"survey" managerIndex:1];
-    [interactions setTextIdentifierAndIndexWithString:@"interaction" rootText:@"interaction" managerIndex:2];
+    [labels setTextIdentifierAndIndexWithSingleIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_label_single", @"Localizable", nil)
+                                         pluralIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_label_plural", @"Localizable", nil) managerIndex:0];
+    [surveys setTextIdentifierAndIndexWithSingleIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_question_single", @"Localizable", nil)
+                                          pluralIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_question_plural", @"Localizable", nil)
+                                              managerIndex:1];
+    [surveys setTextIdentifierForManagerWithSingleIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_single", @"Localizable", nil)
+                                            pluralIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_plural", @"Localizable", nil)];
+    [interactions setTextIdentifierAndIndexWithSingleIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_interaction_single", @"Localizable", nil)
+                                               pluralIdentifier: NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_interaction_plural", @"Localizable", nil) managerIndex:2];
     
     //ManagerArray stores each controller or manager
     labels.delegate = self;
@@ -78,32 +84,34 @@
 - (NSArray*)returnInternationalStudentsArray{
     
     NSArray *filterData;
+    NSString *placeHolderText =  NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_placeHolder", @"Localizable", nil);
+    
     MHFilterLabel *checkListLabel = [[MHFilterLabel alloc] initLabelWithName:@"English Name" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel2 = [[MHFilterLabel alloc] initLabelWithName:@"姓名（汉字)" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel2 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel2 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel3 = [[MHFilterLabel alloc] initLabelWithName:@"Spiritual Status" checked:NO interactionType:CRUCellViewInteractionCheckList];
     [checkListLabel3 setResultsWithKeyArray:@[@"Unknown", @"Non-believer, uninterested", @"Non-believer, seeking", @"Believer, new/needs follow-up", @"Believer, established/growing", @"Believer, ministering", @"Believer, multiplying", @"No Response"] resultValues:@[@NO, @NO, @NO, @NO, @NO, @NO, @NO, @NO]];
     MHFilterLabel *checkListLabel4 = [[MHFilterLabel alloc] initLabelWithName:@"Martial Status" checked:NO interactionType:CRUCellViewInteractionCheckList];
     [checkListLabel4 setResultsWithKeyArray:@[@"Single", @"Married", @"Divorced", @"No Response"] resultValues:@[@NO, @NO, @NO, @NO]];
     MHFilterLabel *checkListLabel5 = [[MHFilterLabel alloc] initLabelWithName:@"Spouse" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel5 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel5 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel6 = [[MHFilterLabel alloc] initLabelWithName:@"Children" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel6 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel6 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel7 = [[MHFilterLabel alloc] initLabelWithName:@"Hometown/Province" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel7 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel7 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel8 = [[MHFilterLabel alloc] initLabelWithName:@"University in Home Country" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel8 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel8 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel9 = [[MHFilterLabel alloc] initLabelWithName:@"Major/Field of Study" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel9 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel9 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel10 = [[MHFilterLabel alloc] initLabelWithName:@"Church" checked:NO interactionType:CRUCellViewInteractionCheckList];
     [checkListLabel10 setResultsWithKeyArray:@[@"中华教会 OCC (Bumby/Rouse)", @"福音教会 OCECC", @"灵粮堂 Bread of Life (Red Bug)", @"台福教会 Dr. Wu's", @"基石教会 Living Stone", @"Other", @"None", @"No Response"] resultValues:@[@NO, @NO, @NO, @NO, @NO, @NO, @NO, @NO]];
     MHFilterLabel *checkListLabel11 = [[MHFilterLabel alloc] initLabelWithName:@"Church(if other)" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel11 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel11 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel12 = [[MHFilterLabel alloc] initLabelWithName:@"Date of Arrival in Orlando" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel12 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel12 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel13 = [[MHFilterLabel alloc] initLabelWithName:@"Date of Departure in Orlando" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel13 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel13 setPlaceHolderTextWithString:placeHolderText];
     MHFilterLabel *checkListLabel14 = [[MHFilterLabel alloc] initLabelWithName:@"Notes" checked:NO interactionType:CRUCellViewInteractionTextBox];
     filterData = @[checkListLabel, checkListLabel2, checkListLabel3, checkListLabel4, checkListLabel5, checkListLabel6, checkListLabel7, checkListLabel8, checkListLabel9, checkListLabel10,
                    checkListLabel11, checkListLabel12, checkListLabel13, checkListLabel14];
@@ -121,17 +129,19 @@
 
 - (NSArray*)returnGuestbookArray{
     
+    NSString *placeHolderText =  NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_survey_placeHolder", @"Localizable", nil);
+    
     MHFilterLabel *checkListLabel = [[MHFilterLabel alloc] initLabelWithName:@"What is your email address?" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel setPlaceHolderTextWithString:placeHolderText];
     
     MHFilterLabel *checkListLabel2 = [[MHFilterLabel alloc] initLabelWithName:@"What is your gender?" checked:NO interactionType:CRUCellViewInteractionCheckList];
     [checkListLabel2 setResultsWithKeyArray:@[@"Female", @"Male", @"No Response"] resultValues:@[@NO, @NO, @NO]];
     
     MHFilterLabel *checkListLabel3 = [[MHFilterLabel alloc] initLabelWithName:@"What is your home country?" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel3 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel3 setPlaceHolderTextWithString:placeHolderText];
     
     MHFilterLabel *checkListLabel4 = [[MHFilterLabel alloc] initLabelWithName:@"What is your home country?" checked:NO interactionType:CRUCellViewInteractionTextBox];
-    [checkListLabel4 setPlaceHolderTextWithString:@"Type keywords for survey answer here"];
+    [checkListLabel4 setPlaceHolderTextWithString:placeHolderText];
     
     MHFilterLabel *checkListLabel5 = [[MHFilterLabel alloc] initLabelWithName:@"How long have you been in America?" checked:NO interactionType:CRUCellViewInteractionCheckList];
     [checkListLabel5 setResultsWithKeyArray:@[@"Less than 1 month", @"1-3 months", @"4-12 months", @"1-2 years", @"2+ years", @"No Response"] resultValues:@[@NO, @NO, @NO, @NO, @NO, @NO]];

--- a/CollapsibleExample/MHCollapsibleSection.h
+++ b/CollapsibleExample/MHCollapsibleSection.h
@@ -23,9 +23,10 @@
 - (instancetype)initWithArray:(NSArray*)filters headerTitle:(NSString*)headerTitle
                      animation:(UITableViewRowAnimation)animation rowRange:(NSRange)rowRange;
 
-//A singleton idenfitier for example labels, surveys, etc.
-//What entities are actually selected
-- (void)setIdentifierWithString:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier;
+//A singleton idenfitier for example selected labels, surveys, etc.
+//What entities are actually selected and specifying selected text since a different language could have
+//# entity selected instead of # selected entity
+- (void)setSelectedIdentifierWithSingleIdentifier:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier;
 
 //Manager index identifies which manager this section belongs too
 //it makes it easier for the filterviewcontroller to interact

--- a/CollapsibleExample/MHCollapsibleSection.h
+++ b/CollapsibleExample/MHCollapsibleSection.h
@@ -25,7 +25,7 @@
 
 //A singleton idenfitier for example labels, surveys, etc.
 //What entities are actually selected
-- (void)setIdentifierWithString:(NSString*)identifier;
+- (void)setIdentifierWithString:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier;
 
 //Manager index identifies which manager this section belongs too
 //it makes it easier for the filterviewcontroller to interact

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -198,7 +198,6 @@ static const NSUInteger numOfSectionsForChecklist = 1;
     NSUInteger count = self.selectedCountForSubTitleText;
     NSString *detailedText;
     NSString *itemTitle = self.getIdentifier;
-    NSString *textPlacement = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_placement", @"Localizable", nil);
     
     if(itemTitle == nil){
         itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
@@ -211,7 +210,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
         }
     }
     
-    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, itemTitle];
+    detailedText = [NSString stringWithFormat:NSLocalizedString(itemTitle, nil), count];
     itemTitle = nil;
     return detailedText;
 }

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -59,7 +59,8 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 }
 
 #pragma Set Section Specifics
-- (void)setIdentifierWithString:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier{
+//What entities are actually selected
+- (void)setSelectedIdentifierWithSingleIdentifier:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier{
     
     self.singleIdentifier = singleIdentifier;
     self.pluralIdentifier = pluralIdentifier;
@@ -198,23 +199,20 @@ static const NSUInteger numOfSectionsForChecklist = 1;
     NSString *detailedText;
     NSString *itemTitle = self.getIdentifier;
     NSString *textPlacement = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_placement", @"Localizable", nil);
-    NSString *selected = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_selectedText", @"Localizable", nil);
     
     if(itemTitle == nil){
         itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
     }
     
     if(count < 1){
-        selected = @"";
         count = self.itemCount;
         if(count > 1){
             itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_plural", @"Localizable", nil);
         }
     }
     
-    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, selected, itemTitle];
+    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, itemTitle];
     itemTitle = nil;
-    selected = nil;
     return detailedText;
 }
 

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -12,7 +12,8 @@
 
 @property (strong, nonatomic) NSArray *filterDataForSection;
 @property (strong, nonatomic) NSString *headerTitle;
-@property (strong, nonatomic) NSString *identifier;
+@property (strong, nonatomic) NSString *pluralIdentifier;
+@property (strong, nonatomic) NSString *singleIdentifier;
 @property (nonatomic) BOOL expanded;
 //This range is key to keep track where to insert/delete
 //it changes depending on sections around it expanding/collapsing
@@ -40,10 +41,13 @@ static const NSUInteger numOfSectionsForChecklist = 1;
                      animation:(UITableViewRowAnimation)animation rowRange:(NSRange)rowRange{
     
     self = [self init];
-    self.filterDataForSection = filters;
-    self.headerTitle = headerTitle;
-    self.filterDataRange = rowRange;
-    self.expanded = false;
+    if(self){
+        
+        self.filterDataForSection = filters;
+        self.headerTitle = headerTitle;
+        self.filterDataRange = rowRange;
+        self.expanded = false;
+    }
     return self;
 }
 
@@ -55,9 +59,10 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 }
 
 #pragma Set Section Specifics
-- (void)setIdentifierWithString:(NSString *)identifier{
+- (void)setIdentifierWithString:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier{
     
-    self.identifier = identifier;
+    self.singleIdentifier = singleIdentifier;
+    self.pluralIdentifier = pluralIdentifier;
 }
 
 - (void)setManagerIndexWithIndex:(NSUInteger)index{
@@ -70,7 +75,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
     //set index to offset so that it will be the proper counter in the array
     self.currentModalIndex = row-self.filterDataRange.location-1;
     
-    MHFilterLabel *label = [self.filterDataForSection objectAtIndex:self.currentModalIndex];
+    MHFilterLabel *label = self.filterDataForSection[self.currentModalIndex];
     
     if(label.labelType == CRUCellViewInteractionTextBox){
         if(!label.resultsKeysExists){
@@ -123,7 +128,14 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 
 - (NSString*)getIdentifier{
     
-    return self.identifier;
+    NSString *identifier;
+    if(self.selectedCountForSubTitleText > 1){
+        identifier = self.pluralIdentifier;
+    }
+    else{
+        identifier = self.singleIdentifier;
+    }
+    return identifier;
 }
 
 - (void)toggleExpanded{
@@ -182,32 +194,26 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 
 - (NSString*)detailedHeaderSectionText{
     
-    NSUInteger count = [self selectedCountForSubTitleText];
+    NSUInteger count = self.selectedCountForSubTitleText;
     NSString *detailedText;
-    NSString *itemTitle = self.identifier;
-    NSString *plural = @"";
-    NSString *selected = @"selected";
+    NSString *itemTitle = self.getIdentifier;
+    NSString *textPlacement = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_placement", @"Localizable", nil);
+    NSString *selected = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_selectedText", @"Localizable", nil);
     
     if(itemTitle == nil){
-        itemTitle = @"item";
+        itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
     }
     
     if(count < 1){
         selected = @"";
-        itemTitle = @"item";
         count = self.itemCount;
         if(count > 1){
-            plural = @"s";
+            itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_plural", @"Localizable", nil);
         }
     }
-    else{
-        if(count > 1){
-            plural = @"s";
-        }
-    }
-    detailedText = [NSString stringWithFormat:NSLocalizedString(@"%i %@ %@%@",), count, selected, itemTitle, plural];
+    
+    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, selected, itemTitle];
     itemTitle = nil;
-    plural = nil;
     selected = nil;
     return detailedText;
 }
@@ -387,7 +393,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 # pragma Changes Triggered By Modals
 - (void)saveChanges{
     
-    MHFilterLabel *label = [self.filterDataForSection objectAtIndex:self.currentModalIndex];
+    MHFilterLabel *label = self.filterDataForSection[self.currentModalIndex];
     //sets the working dictionary to the static to save changes made by user
     //also resets variables that drive what dictionary is traversed for the label
     [label saveResultsFromChanges];
@@ -396,7 +402,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 
 - (void)cancelChanges{
     
-    MHFilterLabel *label = [self.filterDataForSection objectAtIndex:self.currentModalIndex];
+    MHFilterLabel *label = self.filterDataForSection[self.currentModalIndex];
     //sets the working dictionary to the static to override the users changes
     [label cancelChanges];
     label = nil;
@@ -405,7 +411,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
 
 - (void)clearSelections{
     
-    MHFilterLabel *label = [self.filterDataForSection objectAtIndex:self.currentModalIndex];
+    MHFilterLabel *label = self.filterDataForSection[self.currentModalIndex];
     //goes through selected dictionary (what user sees) and unchecks
     //every result entry that has been checked
     [label clearSelectedResults];

--- a/CollapsibleExample/MHFilterLabel.m
+++ b/CollapsibleExample/MHFilterLabel.m
@@ -304,6 +304,11 @@ static const NSUInteger textAreaRow = 0;
 - (void)clearAndSaveChanges{
     
     [self clearMutableResults];
+    if(self.type == CRUCellViewInteractionTextBox){
+        
+        self.currentText = @"";
+        self.resultKeys = @[self.currentText];
+    }
     self.resultValues = [[NSArray alloc] initWithArray:self.mutableResultValues copyItems:YES];
 }
 

--- a/CollapsibleExample/MHPackagedFilter.m
+++ b/CollapsibleExample/MHPackagedFilter.m
@@ -28,7 +28,9 @@
 
 - (void)addFilterWithKey:(NSString*)key value:(NSString*)value{
     
-    [self.filterKeyValuePairs addObject:@{key: value}];
+    MHKeyValuePair *keyValue = [[MHKeyValuePair alloc] initWithKey:key value:value];
+    [self.filterKeyValuePairs addObject:keyValue];
+    keyValue = nil;
     
 }
 

--- a/CollapsibleExample/MHPackagedFilter.m
+++ b/CollapsibleExample/MHPackagedFilter.m
@@ -28,9 +28,7 @@
 
 - (void)addFilterWithKey:(NSString*)key value:(NSString*)value{
     
-    MHKeyValuePair *keyValue = [[MHKeyValuePair alloc] initWithKey:key value:value];
-    [self.filterKeyValuePairs addObject:keyValue];
-    keyValue = nil;
+    [self.filterKeyValuePairs addObject:@{key: value}];
     
 }
 

--- a/CollapsibleExample/en.lproj/Main.strings
+++ b/CollapsibleExample/en.lproj/Main.strings
@@ -1,0 +1,27 @@
+
+/* Class = "UILabel"; text = "Detail"; ObjectID = "10O-kb-IB0"; */
+"10O-kb-IB0.text" = "Detail";
+
+/* Class = "UILabel"; text = "Title"; ObjectID = "89S-va-4z4"; */
+"89S-va-4z4.text" = "Title";
+
+/* Class = "UIBarButtonItem"; title = "Menu"; ObjectID = "Ivq-dp-HFz"; */
+"Ivq-dp-HFz.title" = "Menu";
+
+/* Class = "UIBarButtonItem"; title = "Cancel"; ObjectID = "JuX-r5-ZVm"; */
+"JuX-r5-ZVm.title" = "Cancel";
+
+/* Class = "UIBarButtonItem"; title = "Save"; ObjectID = "Kxk-7q-j38"; */
+"Kxk-7q-j38.title" = "Save";
+
+/* Class = "UINavigationItem"; title = "Contacts"; ObjectID = "SWp-Xb-mlc"; */
+"SWp-Xb-mlc.title" = "Contacts";
+
+/* Class = "UIBarButtonItem"; title = "Clear"; ObjectID = "dHR-6S-gM8"; */
+"dHR-6S-gM8.title" = "Clear";
+
+/* Class = "UINavigationItem"; title = "Filter"; ObjectID = "qTJ-qa-udj"; */
+"qTJ-qa-udj.title" = "Filter";
+
+/* Class = "UIBarButtonItem"; title = "Filter"; ObjectID = "rfF-Gh-bIn"; */
+"rfF-Gh-bIn.title" = "Filter";

--- a/MHCollapsibleViewManager.h
+++ b/MHCollapsibleViewManager.h
@@ -28,19 +28,9 @@
 
 @end
 
-@interface MHCollapsibleViewManagerDeletegate : NSObject{
-    
-    id <MHCollapibleViewManagerDelegate> _delegate;
-}
-
-
-- (void) createModalWithType:(CRUCellViewInteractionType)cellType section:(MHCollapsibleSection*)section rowPath:(NSIndexPath*)rowPath;
-
-@end
-
 @interface MHCollapsibleViewManager : NSObject
 
-@property (nonatomic, strong) id delegate;
+@property (nonatomic, weak) id delegate;
 
 //INIT METHODS
 
@@ -60,7 +50,10 @@
 
 //Identifier is a singleton of what are the sections, ex: label, question
 //while rootText gives the root such as survey
-- (void)setTextIdentifierAndIndexWithString:(NSString*)identifier rootText:(NSString*)rootText managerIndex:(NSUInteger)managerIndex;
+- (void)setTextIdentifierAndIndexWithSingleIdentifier:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier managerIndex:(NSUInteger)managerIndex;
+
+//If this is not set, the manager will use the sections identifier combo above
+- (void)setTextIdentifierForManagerWithSingleIdentifier:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier;
 
 //RETURN METHODS
 

--- a/MHCollapsibleViewManager.m
+++ b/MHCollapsibleViewManager.m
@@ -122,7 +122,7 @@
     
     [self.filterSections enumerateObjectsUsingBlock:^(MHCollapsibleSection *section, NSUInteger index, BOOL *stop){
         
-        [section setIdentifierWithString:singleIdentifier pluralIdentifier:pluralIdentifier];
+        [section setSelectedIdentifierWithSingleIdentifier:singleIdentifier pluralIdentifier:pluralIdentifier];
         [section setManagerIndexWithIndex:managerIndex];
     }];
     
@@ -271,23 +271,20 @@
     NSString *detailedText;
     NSString *itemTitle = self.getIdentifier;
     NSString *textPlacement = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_placement", @"Localizable", nil);
-    NSString  *selected = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_selectedText", @"Localizable", nil);
     
     if(itemTitle == nil){
         itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
     }
     
     if(count < 1){
-        selected = @"";
         count = self.filterSections.count;
         if(count > 1){
             itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_plural", @"Localizable", nil);
         }
     }
-    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, selected, itemTitle];
+    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, itemTitle];
     
     itemTitle = nil;
-    selected = nil;
     return detailedText;
 }
 

--- a/MHCollapsibleViewManager.m
+++ b/MHCollapsibleViewManager.m
@@ -270,7 +270,6 @@
     NSUInteger count = self.numOfSelectedRowsForText;
     NSString *detailedText;
     NSString *itemTitle = self.getIdentifier;
-    NSString *textPlacement = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_placement", @"Localizable", nil);
     
     if(itemTitle == nil){
         itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
@@ -282,7 +281,7 @@
             itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_plural", @"Localizable", nil);
         }
     }
-    detailedText = [NSString stringWithFormat:NSLocalizedString(textPlacement,nil), count, itemTitle];
+    detailedText = [NSString stringWithFormat:NSLocalizedString(itemTitle,nil), count];
     
     itemTitle = nil;
     return detailedText;

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -5,22 +5,19 @@
   Created by Lizzy Randall on 6/15/15.
   Copyright (c) 2015 Lizzy Randall. All rights reserved.
 */
-/*Filter - helpful to have a number of some sort so # __ items"*/
-"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@";
-/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller*/
-"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
-"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
-/*If entitiy gets selected for filter, the text will say # selected ...*/
-"MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
+/*FilterViewController strings, please note most of these have number in placement, required for any language*/
+/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller includes # identifier*/
+"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "%i item";
+"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "%i items";
 /*Filter text entity for labels*/
-"MHFilterViewController_Interaction_CellHeader_label_single" = "selected label";
-"MHFilterViewController_Interaction_CellHeader_label_plural" = "selected labels";
+"MHFilterViewController_Interaction_CellHeader_label_single" = "%i selected label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "%i selected labels";
 /*Filter text entities for surveys*/
-"MHFilterViewController_Interaction_CellHeader_survey_single" = "selected survey";
-"MHFilterViewController_Interaction_CellHeader_survey_plural" = "selected surveys";
-"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "selected question";
-"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "selected questions";
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "%i selected survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "%i selected surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "%i selected question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "%i selected questions";
 "MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
 /*Filter Text entity for interactions*/
-"MHFilterViewController_Interaction_CellHeader_interaction_single" = "selected interaction";
-"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "selected interactions";
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "%i selected interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "%i selected interactions";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -1,0 +1,20 @@
+/* 
+  Localizable.strings
+  CollapsibleExample
+
+  Created by Lizzy Randall on 6/15/15.
+  Copyright (c) 2015 Lizzy Randall. All rights reserved.
+*/
+"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@ %@";
+"MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
+"MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
+"MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
+"MHFilterViewController_Interaction_CellHeader_label_single" = "label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "labels";
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "questions";
+"MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "interactions";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -5,16 +5,22 @@
   Created by Lizzy Randall on 6/15/15.
   Copyright (c) 2015 Lizzy Randall. All rights reserved.
 */
-"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@ %@";
+/*Filter - helpful to have a number of some sort so # __ items"*/
+"MHFilterViewController_Interaction_CellHeader_defaultText_placement" = "%i %@";
+/*Default entity text for MHCollapsibleViewManager if one not provided by viewcontroller*/
 "MHFilterViewController_Interaction_CellHeader_defaultText_single" = "item";
 "MHFilterViewController_Interaction_CellHeader_defaultText_plural" = "items";
+/*If entitiy gets selected for filter, the text will say # selected ...*/
 "MHFilterViewController_Interaction_CellHeader_selectedText" = "selected";
-"MHFilterViewController_Interaction_CellHeader_label_single" = "label";
-"MHFilterViewController_Interaction_CellHeader_label_plural" = "labels";
-"MHFilterViewController_Interaction_CellHeader_survey_single" = "survey";
-"MHFilterViewController_Interaction_CellHeader_survey_plural" = "surveys";
-"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "question";
-"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "questions";
+/*Filter text entity for labels*/
+"MHFilterViewController_Interaction_CellHeader_label_single" = "selected label";
+"MHFilterViewController_Interaction_CellHeader_label_plural" = "selected labels";
+/*Filter text entities for surveys*/
+"MHFilterViewController_Interaction_CellHeader_survey_single" = "selected survey";
+"MHFilterViewController_Interaction_CellHeader_survey_plural" = "selected surveys";
+"MHFilterViewController_Interaction_CellHeader_survey_question_single" = "selected question";
+"MHFilterViewController_Interaction_CellHeader_survey_question_plural" = "selected questions";
 "MHFilterViewController_Interaction_CellHeader_survey_placeHolder" = "Type keywords for survey answer here";
-"MHFilterViewController_Interaction_CellHeader_interaction_single" = "interaction";
-"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "interactions";
+/*Filter Text entity for interactions*/
+"MHFilterViewController_Interaction_CellHeader_interaction_single" = "selected interaction";
+"MHFilterViewController_Interaction_CellHeader_interaction_plural" = "selected interactions";


### PR DESCRIPTION
There is now a .strings file for the titles used on the headers
I noticed the non hierarchy didn’t refresh instantly with a selection,
so now that happens as well (code in the manager)
I also noticed that clear (filter view clear) still kept the lingering
value on the text field modals so that’s what the code in MHFilterLabel
will now clear out on clearAndSaveChanges
The sections and managers now keep a plural and single identifier just
in case for languages that don’t have a plural or the plural isn’t
tacking on s
Also changed the delegate piece that Harro recommended
@michaelharro if you get a chance to see these are the changes you
suggested minus the key/value pair pieces.
