### PR TITLE
Set Filter Array for Manager a different way

### DIFF
--- a/CollapsibleExample/ExampleSubclassFilterViewController.m
+++ b/CollapsibleExample/ExampleSubclassFilterViewController.m
@@ -11,6 +11,7 @@
 @interface ExampleSubclassFilterViewController ()
 
 - (NSArray*)returnLabelArray;
+- (NSArray*)returnInteractionsArray;
 - (NSArray*)returnAssignedToArray;
 - (NSArray*)returnGuestbookArray;
 - (NSArray*)returnEngelsScaleArray;
@@ -36,20 +37,22 @@
     
     MHCollapsibleViewManager *labels = [[MHCollapsibleViewManager alloc] initManagerWithAnimation:UITableViewRowAnimationMiddle topHierarchyTitle:@"Labels" tableView:self.tableView];
     
+    [labels setFilterArraysWithFirstArrayAsHeaderTitles:@[@"Labels"], self.returnLabelArray, nil];
     //sends double array for filternames and single array for header lines
-    [labels setDataWithFilterNames:self.returnLabelArray headerTitles:@[@"Labels"]];
+    //[labels setDataWithFilterNames:self.returnLabelArray headerTitles:@[@"Labels"]];
     
     MHCollapsibleViewManager *surveys = [[MHCollapsibleViewManager alloc] initManagerWithAnimation:UITableViewRowAnimationMiddle topHierarchyTitle:@"Surveys" tableView:self.tableView];
     
     NSArray *surveyQuestions = @[self.returnGuestbookArray, self.returnEngelsScaleArray, self.returnInternationalStudentsArray];
     NSArray *surveyList = @[@"Bridges@UCF Guestbook", @"Engels Scale", @"International Students"];
-    [surveys setDataWithFilterNames:surveyQuestions headerTitles:surveyList];
+    [surveys setFilterArraysWithFirstArrayAsHeaderTitles:surveyList, self.returnGuestbookArray, self.returnEngelsScaleArray, self.returnInternationalStudentsArray, nil];
     surveyList = nil;
     surveyQuestions = nil;
     
     MHCollapsibleViewManager *interactions = [[MHCollapsibleViewManager alloc] initManagerWithAnimation:UITableViewRowAnimationMiddle topHierarchyTitle:@"Interactions" tableView:self.tableView];
     //Index 0 is title
-    [interactions setDataWithFilterNames:@[self.returnInteractionsArray] headerTitles:@[@"Interactions"]];
+    [interactions setFilterArraysWithFirstArrayAsHeaderTitles:@[@"Interactions"], self.returnInteractionsArray, nil];
+    //[interactions setDataWithFilterNames:@[self.returnInteractionsArray] headerTitles:@[@"Interactions"]];
     
     //do not do plural, just singleton
     //this identifies uniquely what the filters are

--- a/CollapsibleExample/ExampleSubclassFilterViewController.m
+++ b/CollapsibleExample/ExampleSubclassFilterViewController.m
@@ -171,13 +171,13 @@
 }
 - (NSArray*)returnAssignedToArray{
     
-    NSArray* filterData = @[[[MHFilterLabel alloc] initLabelWithName:@"Jan" checked:false interactionType:CRUCellViewInteractionCheckToggle],[[MHFilterLabel alloc] initLabelWithName:@"Sue" checked:false interactionType:CRUCellViewInteractionCheckToggle] , [[MHFilterLabel alloc] initLabelWithName:@"Andy" checked:false interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Peggy" checked:false interactionType:CRUCellViewInteractionCheckToggle]];
+    NSArray* filterData = @[[[MHFilterLabel alloc] initLabelWithName:@"Jan" checked:NO interactionType:CRUCellViewInteractionCheckToggle],[[MHFilterLabel alloc] initLabelWithName:@"Sue" checked:NO interactionType:CRUCellViewInteractionCheckToggle] , [[MHFilterLabel alloc] initLabelWithName:@"Andy" checked:NO interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Peggy" checked:NO interactionType:CRUCellViewInteractionCheckToggle]];
     return filterData;
 }
 
 - (NSArray*)returnInteractionsArray{
     
-    NSArray* filterData = @[[[MHFilterLabel alloc] initLabelWithName:@"Comment Only" checked:false interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Spiritual Conversation" checked:false interactionType:CRUCellViewInteractionCheckToggle],[[MHFilterLabel alloc] initLabelWithName:@"Personal Evangelism" checked:false interactionType:CRUCellViewInteractionCheckToggle] , [[MHFilterLabel alloc] initLabelWithName:@"Personal Evangelism Decisions" checked:false interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Holy Spirit Presentation" checked:false interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Graduating on a Mission" checked:false interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Faculty on Mission" checked:false interactionType:CRUCellViewInteractionCheckToggle]];
+    NSArray* filterData = @[[[MHFilterLabel alloc] initLabelWithName:@"Comment Only" checked:NO interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Spiritual Conversation" checked:NO interactionType:CRUCellViewInteractionCheckToggle],[[MHFilterLabel alloc] initLabelWithName:@"Personal Evangelism" checked:NO interactionType:CRUCellViewInteractionCheckToggle] , [[MHFilterLabel alloc] initLabelWithName:@"Personal Evangelism Decisions" checked:NO interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Holy Spirit Presentation" checked:NO interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Graduating on a Mission" checked:NO interactionType:CRUCellViewInteractionCheckToggle], [[MHFilterLabel alloc] initLabelWithName:@"Faculty on Mission" checked:NO interactionType:CRUCellViewInteractionCheckToggle]];
     return filterData;
 }
 

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -317,14 +317,21 @@ static const NSUInteger numOfSectionsForChecklist = 1;
     
     MHFilterLabel *label = [self.filterDataForSection objectAtIndex:self.currentModalIndex];
     [label setCurrentTextWithString:textField.text];
+    [textField resignFirstResponder];
     label = nil;
 }
-
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField{
     
     return YES;
 }
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField{
+    
+    [textField resignFirstResponder];
+    return YES;
+}
+
 
 #pragma TableViewDelegate
 - (UITableViewCell*)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -46,7 +46,7 @@ static const NSUInteger numOfSectionsForChecklist = 1;
         self.filterDataForSection = filters;
         self.headerTitle = headerTitle;
         self.filterDataRange = rowRange;
-        self.expanded = false;
+        self.expanded = NO;
     }
     return self;
 }

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -205,8 +205,13 @@ static const NSUInteger numOfSectionsForChecklist = 1;
     
     if(count < 1){
         count = self.itemCount;
-        if(count > 1){
+        //plural is needed for 0 items and # of items greater than 1
+        if(count == 0 || count > 1){
             itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_plural", @"Localizable", nil);
+        }
+        //only one item, don't need plural
+        else{
+            itemTitle = NSLocalizedStringFromTable(@"MHFilterViewController_Interaction_CellHeader_defaultText_single", @"Localizable", nil);
         }
     }
     

--- a/CollapsibleExample/MHCollapsibleSection.m
+++ b/CollapsibleExample/MHCollapsibleSection.m
@@ -429,7 +429,9 @@ static const NSUInteger numOfSectionsForChecklist = 1;
         if(label.selectedCell){
             [label toggleChecked];
         }
-        [label clearAndSaveChanges];
+        if(label.containsAtLeastOneSelected > 0){
+            [label clearAndSaveChanges];
+        }
     }];
 }
 

--- a/CollapsibleExample/MHTableViewCell.m
+++ b/CollapsibleExample/MHTableViewCell.m
@@ -72,7 +72,7 @@
     self.accessoryType = self.defaultAccessoryType;
     self.selectionStyle = self.defaultSelectionStyle;
     
-    self.checked = false;
+    self.checked = NO;
     return self;
 }
 

--- a/FilterViewController.m
+++ b/FilterViewController.m
@@ -159,9 +159,7 @@
             
             UIViewController *pickerViewController = [[UIViewController alloc] init];
             [self setButtonsAndColorWithController:pickerViewController bgColor:[UIColor whiteColor] cancel:cancel save:save clear:nil];
-            //[pickerViewController.view addSubview:labelText];
             [pickerViewController.view addSubview:picker];
-  
             
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:pickerViewController];
             [self setSettingsForNavWithController:navigationController cgSize:self.view.bounds.size offSet:self.tableView.contentOffset];
@@ -180,14 +178,15 @@
             UITextField *textField = [self createTextFieldWithSection:section cgSize:self.view.frame.size];
             
             UIViewController *textAreaController = [[UIViewController alloc] init];
-            [self setButtonsAndColorWithController:textAreaController bgColor:[UIColor whiteColor] cancel:cancel save:save clear:nil];
+            [self setButtonsAndColorWithController:textAreaController bgColor:[UIColor whiteColor] cancel:cancel save:save clear:clear];
             
             [textAreaController.view addSubview:descriptionText];
             [textAreaController.view addSubview:textField];
             
+            
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:textAreaController];
-            [self setSettingsForNavWithController:navigationController cgSize:self.view.bounds.size offSet:self.tableView.contentOffset];
-            [self bringUpHalfModalWithController:navigationController cgSize:self.view.bounds.size offSet:self.tableView.contentOffset];
+            navigationController.toolbarHidden = NO;
+            [self presentViewController:navigationController animated:YES completion:nil];
             
             navigationController = nil;
             textAreaController = nil;
@@ -328,7 +327,7 @@
     [self.currentSection saveChanges];
     
     //since checklist type uses real modal
-    if(self.currentModalType != CRUCellViewInteractionCheckList){
+    if(self.currentModalType != CRUCellViewInteractionCheckList && self.currentModalType != CRUCellViewInteractionTextBox){
     
         //currentSubViewControllerIndex is set as 0 by default in viewDidLoad
         UINavigationController *navigationController = self.childViewControllers[self.currentSubViewControllerIndex];
@@ -367,7 +366,7 @@
     [self.currentSection cancelChanges];
     
     //since checklist type is a true modal
-    if(self.currentModalType != CRUCellViewInteractionCheckList){
+    if(self.currentModalType != CRUCellViewInteractionCheckList && self.currentModalType != CRUCellViewInteractionTextBox){
     
         //currentSubViewControllerIndex is set as 0 by default in viewDidLoad
         UINavigationController *navigationController = self.childViewControllers[self.currentSubViewControllerIndex];
@@ -423,7 +422,7 @@
 - (void)resignFirstResponderWithClearOption:(BOOL)clear{
     
     //currentSubViewControllerIndex set 0 default in viewdidload
-    UINavigationController *navigationController = (UINavigationController*)self.childViewControllers[self.currentSubViewControllerIndex];
+    UINavigationController *navigationController = (UINavigationController*)self.presentedViewController;
     UIViewController *textFieldViewController = navigationController.topViewController;
     
     [textFieldViewController.view.subviews enumerateObjectsUsingBlock:^(UIView *view, NSUInteger index, BOOL *stop){

--- a/FilterViewController.m
+++ b/FilterViewController.m
@@ -26,6 +26,13 @@
     self.currentSubViewControllerIndex = 0;
 }
 
+- (void)viewDidDisappear:(BOOL)animated{
+    
+    [super viewDidDisappear:animated];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+}
+
 #pragma Set Modal and Manager Settings
 //Can be overwritten or added onto since the objects exist on the class
 //rather than in the method

--- a/MHCollapsibleViewManager.h
+++ b/MHCollapsibleViewManager.h
@@ -55,6 +55,8 @@
 //If this is not set, the manager will use the sections identifier combo above
 - (void)setTextIdentifierForManagerWithSingleIdentifier:(NSString *)singleIdentifier pluralIdentifier:(NSString*)pluralIdentifier;
 
+- (void)setFilterArraysWithFirstArrayAsHeaderTitles:(NSArray*)firstArray, ... NS_REQUIRES_NIL_TERMINATION;
+
 //RETURN METHODS
 
 - (MHTableViewCell*)returnCellWithIndex:(NSIndexPath*)indexPath tableView:(UITableView*)tableView;

--- a/MHCollapsibleViewManager.m
+++ b/MHCollapsibleViewManager.m
@@ -66,6 +66,57 @@
 }
 
 #pragma Initial Settings
+
+- (void)setFilterArraysWithFirstArrayAsHeaderTitles:(NSArray*)firstArray, ... NS_REQUIRES_NIL_TERMINATION{
+    
+    NSArray *headerTitles = firstArray;
+    __block NSArray *filterArray = firstArray;
+    __block NSUInteger count = 0; //tells of hierarchy
+    __block MHCollapsibleSection *section;
+    __block NSUInteger filterCount =  0;
+    __block NSUInteger start = 1;
+    __block NSRange range;
+    
+    //Defaults to hierarchy, based on count that will change
+    self.hierarchy = YES;
+    self.expanded = NO;
+    
+    va_list arguments;
+    //va start makes firstArray skipped, the first argument in loop
+    //is actually the second argument, this is what is wanted
+    //since header titles is the firstArray
+    va_start(arguments, firstArray);
+
+    while((filterArray = va_arg(arguments, NSArray*))){
+        
+        filterCount = filterArray.count+1;//offset for section header row, length includes header
+        range = NSMakeRange(start, filterCount);
+        section = [MHCollapsibleSection alloc];
+        section = [section initWithArray:filterArray headerTitle:headerTitles[count] animation:self.rowAnimation rowRange:range];
+        [self.filterSections addObject:section];
+        start++;
+        count++;
+    }
+    va_end(arguments);
+    
+    //Only one array, this is not a hierarchy
+    //so the starting range needs to not be one off
+    //start is originally 1 for the manager's header
+    if(count < 2){
+        
+        start = 0;
+
+        //There should be only one section in this manager, but the loop is better to code for just in case
+        [self.filterSections enumerateObjectsUsingBlock:^(MHCollapsibleSection *loopSection, NSUInteger index, BOOL *stop){
+                
+            [loopSection resetRangeWithNum:start];
+        }];
+        self.hierarchy = NO;
+        self.expanded = YES;
+    }
+
+}
+
 //called after Initializing Manager
 //can take double array or single array depending if hierarchy
 - (void)setDataWithFilterNames:(NSArray*)filterNames headerTitles:(NSArray*)headerTitles {

--- a/MHCollapsibleViewManager.m
+++ b/MHCollapsibleViewManager.m
@@ -19,8 +19,8 @@
 //otherwise there is just one MHCollapsibleSection dictating itself
 @property (nonatomic) BOOL hierarchy;
 //Boolean keeps track if header has been clicked
-//expanded = true means children rows are shown
-//expanded = false means children rows are not shown
+//expanded = YES means children rows are shown
+//expanded = NO means children rows are not shown
 @property (nonatomic) BOOL expanded;
 
 - (void)toggleCollapse:(UITableView*)tableView indexPath:(NSIndexPath*)indexPath;
@@ -43,9 +43,9 @@
     self = [super init];
     if(self){
         self.filterSections = [NSMutableArray alloc];
-        self.hierarchy = false;
+        self.hierarchy = NO;
         self.headerTitle = @"";
-        self.expanded = false;
+        self.expanded = NO;
         self.rowAnimation = UITableViewRowAnimationFade;
     }
     return self;
@@ -58,7 +58,7 @@
     self = [self init];
     if(self){
         self.headerTitle = title;
-        self.hierarchy = false;
+        self.hierarchy = NO;
         self.rowAnimation = animation;
         self.filterSections = [self.filterSections init];
     }
@@ -149,9 +149,9 @@
         //filterNames should have multiple arrays if it was a hierarchy
         //if just one, it's treated the same as a regular array, single MHCollapsibleSection
         if(filterCount > 1 && [[filterNames objectAtIndex:0] isKindOfClass: [NSArray class]]){
-            self.hierarchy = true;
+            self.hierarchy = YES;
             start += 1;
-            self.expanded = false;
+            self.expanded = NO;
         }
         
         if(headerTitles.count == filterCount){
@@ -346,7 +346,7 @@
     __block  NSString *cellText = nil;
     __block  NSString *detailText = nil;
     __block  NSUInteger indexRow = indexPath.row;
-    __block  BOOL collapsed = false;
+    __block  BOOL collapsed = NO;
     
     //handle Manager specifics
     if(self.hierarchy && indexRow == 0){

--- a/MHCollapsibleViewManager.m
+++ b/MHCollapsibleViewManager.m
@@ -70,12 +70,12 @@
 - (void)setFilterArraysWithFirstArrayAsHeaderTitles:(NSArray*)firstArray, ... NS_REQUIRES_NIL_TERMINATION{
     
     NSArray *headerTitles = firstArray;
-    __block NSArray *filterArray = firstArray;
-    __block NSUInteger count = 0; //tells of hierarchy
-    __block MHCollapsibleSection *section;
-    __block NSUInteger filterCount =  0;
-    __block NSUInteger start = 1;
-    __block NSRange range;
+    NSArray *filterArray = firstArray;
+    NSUInteger count = 0; //tells of hierarchy
+    MHCollapsibleSection *section;
+    NSUInteger filterCount =  0;
+    NSUInteger start = 1;
+    NSRange range;
     
     //Defaults to hierarchy, based on count that will change
     self.hierarchy = YES;
@@ -108,7 +108,6 @@
 
         //There should be only one section in this manager, but the loop is better to code for just in case
         [self.filterSections enumerateObjectsUsingBlock:^(MHCollapsibleSection *loopSection, NSUInteger index, BOOL *stop){
-                
             [loopSection resetRangeWithNum:start];
         }];
         self.hierarchy = NO;


### PR DESCRIPTION
@ryancarlson @michaelharro @jonvellacott Since Ryan was saying the double arrays/array of arrays are complex, I made a nil termination method instead. This would have
the format just like NSstring's stringWithFormat:  methods where nil would be the
terminator at the end. It takes the header titles (“Survey Name” or
“Label”) array first then the filter arrays after. I show an example of
non hierarchy and hierarchy in the subclass.

Apple docs on variadic methods: https://developer.apple.com/library/mac/qa/qa1405/_index.html

Is this better and easier for developers to use?
